### PR TITLE
Refactored prop.OriginalValue check logic

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
+++ b/src/Microsoft.EntityFrameworkCore.AutoHistory/Extensions/DbContextExtensions.cs
@@ -77,13 +77,24 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         if (prop.IsModified)
                         {
-                            //bef[prop.Metadata.Name] = prop.OriginalValue != null
-                            //? JToken.FromObject(prop.OriginalValue, jsonSerializer)
-                            //: JValue.CreateNull();
-                            var originalValue = entry.GetDatabaseValues().GetValue<object>(prop.Metadata.Name);
-                            bef[prop.Metadata.Name] = originalValue != null
-                            ? JToken.FromObject(originalValue, jsonSerializer)
-                            : JValue.CreateNull();
+                            if (prop.OriginalValue != null)
+                            {
+                                if (prop.OriginalValue != prop.CurrentValue)
+                                {
+                                    bef[prop.Metadata.Name] = JToken.FromObject(prop.OriginalValue, jsonSerializer);
+                                }
+                                else
+                                {
+                                    var originalValue = entry.GetDatabaseValues().GetValue<object>(prop.Metadata.Name);
+                                    bef[prop.Metadata.Name] = originalValue != null
+                                        ? JToken.FromObject(originalValue, jsonSerializer)
+                                        : JValue.CreateNull();
+                                }
+                            }
+                            else
+                            {
+                                bef[prop.Metadata.Name] = JValue.CreateNull();
+                            }
 
                             aft[prop.Metadata.Name] = prop.CurrentValue != null
                             ? JToken.FromObject(prop.CurrentValue, jsonSerializer)


### PR DESCRIPTION
Refactored prop.OriginalValue check logic to make DB call only when prop.OriginalValue == prop.CurrentValue means we have disconnected entity instance in which case EF has no info on what the original values were.  Either DB call needs to be made here or at the original place so we have connected entity instance.